### PR TITLE
Bump package constraints for stack LTS 23

### DIFF
--- a/prometheus-wai-middleware.cabal
+++ b/prometheus-wai-middleware.cabal
@@ -31,11 +31,11 @@ library
     Network.Wai.Middleware.Prometheus
   build-depends:
       base        >= 4.12  && < 5
-    , containers  >= 0.5   && < 0.7
+    , containers  >= 0.5   && < 0.8
     , clock      ^>= 0.8
     , http-types  >= 0.8   && < 0.13
-    , prometheus ^>= 2.2
-    , text        >= 1.2   && < 2.1
+    , prometheus ^>= 2.3
+    , text        >= 1.2   && < 2.2
     , wai        ^>= 3.2
 
 
@@ -47,7 +47,7 @@ executable prometheus-wai-middleware-example
       async                     ^>= 2.2
     , base                       >= 4.12  && < 5
     , http-types                 >= 0.8   && < 0.13
-    , prometheus                ^>= 2.2
+    , prometheus                ^>= 2.3
     , prometheus-wai-middleware
     , wai                       ^>= 3.2
     , warp                       >= 3.2   && < 3.5

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,3 @@
-resolver: lts-21.25
-extra-deps:
-  - "prometheus-2.2.4@sha256:a6691f50b6bd1b2e95138ca2fbd7c31c888da8b2c3157de1583eb99746f9d737,4288"
+resolver: lts-23.3
 ghc-options:
   "$locals": -Wall

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -3,17 +3,10 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages:
-- completed:
-    hackage: prometheus-2.2.4@sha256:a6691f50b6bd1b2e95138ca2fbd7c31c888da8b2c3157de1583eb99746f9d737,4288
-    pantry-tree:
-      sha256: 4c6aa464e6f72cd68ad601c67682863331e1e02e4b4732b672603d922830aa12
-      size: 1559
-  original:
-    hackage: prometheus-2.2.4@sha256:a6691f50b6bd1b2e95138ca2fbd7c31c888da8b2c3157de1583eb99746f9d737,4288
+packages: []
 snapshots:
 - completed:
-    sha256: a81fb3877c4f9031e1325eb3935122e608d80715dc16b586eb11ddbff8671ecd
-    size: 640086
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/21/25.yaml
-  original: lts-21.25
+    sha256: dd89d2322cb5af74c6ab9d96c0c5f6c8e6653e0c991d619b4bb141a49cb98668
+    size: 679282
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/23/3.yaml
+  original: lts-23.3


### PR DESCRIPTION
This PR bumps the package constraint to build with stack LTS 23.X

The package deps have been updated in `cabal outdated`