### PR TITLE
feat!: don't count http response codes for websocket connections

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
           - "9.2.8"
           - "9.4.8"
           - "9.6.3"
+          - "9.8.4"
 
     steps:
       - uses: actions/checkout@v4

--- a/prometheus-wai-middleware.cabal
+++ b/prometheus-wai-middleware.cabal
@@ -30,13 +30,14 @@ library
   exposed-modules:
     Network.Wai.Middleware.Prometheus
   build-depends:
-      base        >= 4.12  && < 5
-    , containers  >= 0.5   && < 0.8
-    , clock      ^>= 0.8
-    , http-types  >= 0.8   && < 0.13
-    , prometheus ^>= 2.3
-    , text        >= 1.2   && < 2.2
-    , wai        ^>= 3.2
+      base              >= 4.12  && < 5
+    , case-insensitive ^>= 1.2
+    , containers        >= 0.5   && < 0.8
+    , clock            ^>= 0.8
+    , http-types        >= 0.8   && < 0.13
+    , prometheus       ^>= 2.3
+    , text              >= 1.2   && < 2.2
+    , wai              ^>= 3.2
 
 
 executable prometheus-wai-middleware-example


### PR DESCRIPTION
This changes prometheus-wai-middleware to _not_ count HTTP response codes for websocket connections.

The problem here is that `websocketsOr` from `wai-websockets` uses a backup HTTP 500 response in the definition:

https://hackage.haskell.org/package/wai-websockets-3.0.1.2/docs/src/Network-Wai-Handler-WebSockets.html#websocketsOr

So when `prometheus-wai-middleware` calls `responseStatus` on this response, it gets an HTTP 500 value:

https://hackage.haskell.org/package/wai-3.2.4/docs/src/Network.Wai.html#responseStatus

Like the comment in the PR says, it doesn't _really_ make sense to call `responseStatus` on a websocket connection, because they don't really have an HTTP response status.  Wai is just returning something non-nonsensical here, so we should be ignoring it.